### PR TITLE
Modify Hex entry to more closely resemble PS

### DIFF
--- a/jpicker-1.1.6/jpicker-1.1.6.js
+++ b/jpicker-1.1.6/jpicker-1.1.6.js
@@ -844,28 +844,14 @@
               hex = this.validateHex(hex);
               if (hex == '') return { r: null, g: null, b: null, a: null };
               var r = '00', g = '00', b = '00', a = '255';
+              while (hex.length < 6) {
+                hex = '0' + hex
+              }
               if (hex.length == 6) hex += 'ff';
-              if (hex.length > 6)
-              {
-                r = hex.substring(0, 2);
-                g = hex.substring(2, 4);
-                b = hex.substring(4, 6);
-                a = hex.substring(6, hex.length);
-              }
-              else
-              {
-                if (hex.length > 4)
-                {
-                  r = hex.substring(4, hex.length);
-                  hex = hex.substring(0, 4);
-                }
-                if (hex.length > 2)
-                {
-                  g = hex.substring(2, hex.length);
-                  hex = hex.substring(0, 2);
-                }
-                if (hex.length > 0) b = hex.substring(0, hex.length);
-              }
+              r = hex.substring(0, 2);
+              g = hex.substring(2, 4);
+              b = hex.substring(4, 6);
+              a = hex.substring(6, hex.length);
               return { r: this.hexToInt(r), g: this.hexToInt(g), b: this.hexToInt(b), a: this.hexToInt(a) };
             },
           validateHex:


### PR DESCRIPTION
Entering a hex value such as 345 into photoshop's color picker will result in a 6 digit color hex of #000345. Currently jPicker would return a color of #00000534. Photoshop is prepending 0's to any hex value of length less than 6, whereas jPicker is tagging each two-digit substring as R, G, or B. This becomes a little confusing with values such as 345, where you would expect 03 to be green and not 05.
